### PR TITLE
Allow extra properties in `definitions`

### DIFF
--- a/pipeline_runner/cli.py
+++ b/pipeline_runner/cli.py
@@ -182,9 +182,9 @@ def parse(pipeline: str | None, repository_path: str) -> None:
         parsed = pipelines_definition.get_pipeline(pipeline)
         if not parsed:
             raise InvalidPipelineError(pipeline)
-        click.echo(parsed.json(indent=2))
+        click.echo(parsed.model_dump_json(indent=2))
     else:
-        click.echo(pipelines_definition.json(indent=2))
+        click.echo(pipelines_definition.model_dump_json(indent=2))
 
 
 @main.command()

--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -93,6 +93,8 @@ class Service(BaseModel):
 
 
 class Definitions(BaseModel):
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
     caches: dict[str, str] = Field(default_factory=dict)
     services: dict[str, Service] = Field(default_factory=dict)
 


### PR DESCRIPTION
Allow and ignore any extra properties that could be found under the definition entry. Since Atlassian suggests adding anchors in there, we can't crash if the user does so. Extra properties are ignored anyway since the yaml parser has already expanded the anchors.

See https://support.atlassian.com/bitbucket-cloud/docs/yaml-anchors/

This fixes #10 

Drive-by: Fix a crash when outputting the model in the `parse` command.