### PR TITLE
Use OIDC to publish to PyPI and update actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,14 @@ on:
 
 jobs:
   create-release:
-    name: Create release
+    name: Create Release
     runs-on: ubuntu-latest
+
     outputs:
       upload_url: ${{ steps.create-release.outputs.upload_url }}
+
     steps:
-      - name: Create release
+      - name: Create Release
         id: create-release
         uses: actions/create-release@v1
         env:
@@ -27,14 +29,17 @@ jobs:
           draft: false
           prerelease: false
 
-  build-release:
-    name: build-release
-    needs: ['create-release']
+  build:
+    name: Build Package
     runs-on: ubuntu-latest
+
+    outputs:
+      git_branch: ${{ steps.git_info.outputs.GIT_BRANCH }}
+      git_tag: ${{ steps.git_info.outputs.GIT_TAG }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -48,29 +53,50 @@ jobs:
           echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> "${GITHUB_OUTPUT}"
 
       - name: Build package
-        run: |
-          poetry build
+        run: poetry build
+
+      - name: Save build
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish Package
+    runs-on: ubuntu-latest
+    needs: ['create-release', 'build']
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bitbucket-pipeline-runner
+    permissions:
+      id-token: write  # Needed for publishing to PyPI with OIDC
+
+    steps:
+      - name: Retrieve build
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
       - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ steps.git_info.outputs.GIT_TAG }}.tar.gz
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ steps.git_info.outputs.GIT_TAG }}.tar.gz
+          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
+          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload wheel
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ steps.git_info.outputs.GIT_TAG }}-py3-none-any.whl
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ steps.git_info.outputs.GIT_TAG }}-py3-none-any.whl
+          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
+          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
           asset_content_type: application/zip
 
-      - name: Upload package to PyPI
-        run: |
-          poetry publish --username __token__ --password "${{ secrets.PYPI_TOKEN }}"
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          name: Release ${{ github.ref }}
+          name: Release ${{ needs.build.outputs.GIT_TAG }}
           files: |
             ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
             ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,42 +48,19 @@ jobs:
     needs: ["build"]
 
     steps:
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
       - name: Retrieve build
         uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
 
-      - name: Upload release archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload wheel
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
-          asset_content_type: application/zip
+          files: |
+            ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
+            ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
 
   publish:
     name: Publish Package to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,14 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Tests"]
+  push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
-    types:
-      - completed
 
 jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == "success" }}
 
     outputs:
       git_branch: ${{ steps.git_info.outputs.GIT_BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "*"
 
 jobs:
   build:
@@ -58,6 +58,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          name: Release ${{ github.ref }}
           files: |
             ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
             ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "*"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,33 +2,17 @@
 # https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
 # https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml
 
-name: release
+name: Release
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Tests"]
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+    types:
+      - completed
 
 jobs:
-  create-release:
-    name: Create Release
-    runs-on: ubuntu-latest
-
-    outputs:
-      upload_url: ${{ steps.create-release.outputs.upload_url }}
-
-    steps:
-      - name: Create Release
-        id: create-release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-
   build:
     name: Build Package
     runs-on: ubuntu-latest
@@ -61,10 +45,53 @@ jobs:
           name: dist
           path: dist/
 
-  publish:
-    name: Publish Package
+  create-release:
+    name: Create Github Release
     runs-on: ubuntu-latest
-    needs: ['create-release', 'build']
+    needs: ["build"]
+
+    steps:
+      - name: Create Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Retrieve build
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload release archive
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_name: bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}.tar.gz
+          asset_path: ./dist/bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload wheel
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_name: bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}-py3-none-any.whl
+          asset_path: ./dist/bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}-py3-none-any.whl
+          asset_content_type: application/zip
+
+  publish:
+    name: Publish Package to PyPI
+    runs-on: ubuntu-latest
+    needs: ["build"]
     environment:
       name: pypi
       url: https://pypi.org/p/bitbucket-pipeline-runner
@@ -77,26 +104,6 @@ jobs:
         with:
           name: dist
           path: dist/
-
-      - name: Upload release archive
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload wheel
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
-          asset_content_type: application/zip
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ name: Release
 on:
   push:
     tags:
-      - "*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,18 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*"
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
 
 jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    if: |
+      github.event.workflow_run.conclusion == "success" &&
+        startsWith(github.ref, 'refs/tags/')
 
     outputs:
       git_branch: ${{ steps.git_info.outputs.GIT_BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == "success" }}
 
     outputs:
       git_branch: ${{ steps.git_info.outputs.GIT_BRANCH }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}.tar.gz
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}.tar.gz
+          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
+          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}.tar.gz
           asset_content_type: application/gzip
 
       - name: Upload wheel
@@ -81,8 +81,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_name: bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}-py3-none-any.whl
-          asset_path: ./dist/bitbucket_pipeline_runner-${{ steps.build.outputs.GIT_TAG }}-py3-none-any.whl
+          asset_name: bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
+          asset_path: ./dist/bitbucket_pipeline_runner-${{ needs.build.outputs.GIT_TAG }}-py3-none-any.whl
           asset_content_type: application/zip
 
   publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,14 @@
 name: Release
 
 on:
-  workflow_run:
-    workflows: ["Tests"]
-    types:
-      - completed
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   build:
     name: Build Package
     runs-on: ubuntu-latest
-    if: |
-      github.event.workflow_run.conclusion == "success" &&
-        startsWith(github.ref, 'refs/tags/')
 
     outputs:
       git_branch: ${{ steps.git_info.outputs.GIT_BRANCH }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,6 @@ name: Tests
 
 on:
   push:
-    branches: ["master"]
-
-  pull_request:
     branches: ["*"]
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,8 @@ name: Tests
 
 on:
   push:
-    branches: ["*"]
+    branches: ["master"]
+    #branches: ["*"]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,9 @@ jobs:
           poetry install
 
       - name: Install Just
-        uses: extractions/setup-just@v1
+        uses: taiki-e/install-action@v2
+        with:
+          tool: just
 
       - name: Lint
         uses: pre-commit/action@v3.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: ["master"]
-    #branches: ["*"]
+    branches: ["*"]
 
 jobs:
   tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-pipeline-runner"
-version = "0.0.0a2"
+version = "0.3.11"
 description = "Run a bitbucket pipeline locally"
 authors = ["Mathieu Lemay <acidrain1@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-pipeline-runner"
-version = "0.0.0a0"
+version = "0.0.0a1"
 description = "Run a bitbucket pipeline locally"
 authors = ["Mathieu Lemay <acidrain1@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-pipeline-runner"
-version = "0.3.11"
+version = "0.0.1"
 description = "Run a bitbucket pipeline locally"
 authors = ["Mathieu Lemay <acidrain1@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-pipeline-runner"
-version = "0.0.1"
+version = "0.0.0a0"
 description = "Run a bitbucket pipeline locally"
 authors = ["Mathieu Lemay <acidrain1@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-pipeline-runner"
-version = "0.0.0a1"
+version = "0.0.0a2"
 description = "Run a bitbucket pipeline locally"
 authors = ["Mathieu Lemay <acidrain1@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
- Use OIDC to publish to PyPI instead of a token
- Use `softprops/action-gh-release@v1` instead of manually creating releases
- Replace `extractions/setup-just@v1` by `taiki-e/install-action@v2`