### PR TITLE
Add support for caching with file-based cache keys

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,4 +28,4 @@ clean:
     rm -f .make.* .coverage
 
 @_deps:
-    [[ ! -f .make.poetry || poetry.lock -nt .make.poetry ]] && ( poetry install --sync; touch .make.poetry ) || true
+    [ ! -f .make.poetry ] || [ poetry.lock -nt .make.poetry ] && ( poetry install --sync; touch .make.poetry ) || true

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -4,8 +4,8 @@ definitions:
     invalid: $HOME/.cache/non-existing-folder
     custom:
       key:
-        files: ["file1"]
-      path: some-path
+        files: ["custom-cache-key"]
+      path: ~/.cache/custom
   services:
     postgres:
       image: postgres:alpine
@@ -120,7 +120,9 @@ pipelines:
           caches:
             - custom
           script:
-            - exit 0
+            - export CACHE_DIR=$HOME/.cache/custom
+            - mkdir -p "${CACHE_DIR}"
+            - dd if=/dev/random of=${CACHE_DIR}/file bs=2048 count=1
 
     test_artifacts:
       - step:

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -2,6 +2,10 @@ definitions:
   caches:
     service1: ~/.cache/service1
     invalid: $HOME/.cache/non-existing-folder
+    custom:
+      key:
+        files: ["file1"]
+      path: some-path
   services:
     postgres:
       image: postgres:alpine
@@ -107,6 +111,14 @@ pipelines:
           name: Test Invalid Cache
           caches:
             - invalid
+          script:
+            - exit 0
+
+    test_custom_cache:
+      - step:
+          name: Test Custom Cache
+          caches:
+            - custom
           script:
             - exit 0
 

--- a/pipeline_runner/cache.py
+++ b/pipeline_runner/cache.py
@@ -1,3 +1,4 @@
+import glob
 import hashlib
 import logging
 import os.path
@@ -313,15 +314,15 @@ def compute_cache_key(cache_name: str, cache: CacheType, repository: Repository)
     is_valid = False
     hasher = hashlib.sha256()
 
-    for file in cache.key.files:
-        fp = os.path.join(repository.path, file)
-        if not os.path.isfile(fp):
-            continue
+    for key_file in cache.key.files:
+        for fp in glob.glob(os.path.join(repository.path, key_file), recursive=True):
+            if not os.path.isfile(fp):
+                continue
 
-        is_valid = True
+            is_valid = True
 
-        with open(fp, "rb") as f:
-            hasher.update(f.read())
+            with open(fp, "rb") as f:
+                hasher.update(f.read())
 
     if not is_valid:
         raise InvalidCacheKeyError(cache_name)

--- a/pipeline_runner/cache.py
+++ b/pipeline_runner/cache.py
@@ -138,6 +138,16 @@ class CacheRestore:
 
 
 class NullCacheRestore(CacheRestore):
+    def __init__(
+        self,
+        _container: ContainerRunner,
+        _repository: Repository,
+        _local_cache_directory: str,
+        _cache_definitions: Mapping[str, CacheType],
+        cache_name: str,
+    ) -> None:
+        self._cache_name = cache_name
+
     def restore(self) -> None:
         logger.info("Cache '%s': Ignoring", self._cache_name)
 
@@ -176,7 +186,7 @@ class CacheSave:
         self._cache_key = compute_cache_key(cache_name, cache_definition, repository)
 
     def save(self) -> None:
-        local_cache_archive_path = get_local_cache_archive_path(self._local_cache_directory, self._cache_name)
+        local_cache_archive_path = get_local_cache_archive_path(self._local_cache_directory, self._cache_key)
 
         if not self._cache_should_be_updated(local_cache_archive_path):
             logger.info("You already have a '%s' cache so we won't create it again", self._cache_name)
@@ -244,6 +254,16 @@ class CacheSave:
 
 
 class NullCacheSave(CacheSave):
+    def __init__(
+        self,
+        _container: ContainerRunner,
+        _repository: Repository,
+        _local_cache_directory: str,
+        _cache_definitions: Mapping[str, CacheType],
+        cache_name: str,
+    ) -> None:
+        self._cache_name = cache_name
+
     def save(self) -> None:
         logger.info("Cache '%s': Ignoring", self._cache_name)
 

--- a/pipeline_runner/config.py
+++ b/pipeline_runner/config.py
@@ -3,16 +3,19 @@ import logging
 import os
 from collections.abc import Mapping
 from types import MappingProxyType
-from typing import Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, cast
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 from . import __name__ as __project_name__
 
+if TYPE_CHECKING:
+    from .models import CacheType
+
 DEFAULT_IMAGE: Final[str] = "atlassian/default-image:latest"
 
-DEFAULT_CACHES: Final[dict[str, str]] = {
+DEFAULT_CACHES: Final[dict[str, "CacheType"]] = {
     "composer": "~/.composer/cache",
     "dotnetcore": "~/.nuget/packages",
     "gradle": "~/.gradle/caches ",

--- a/pipeline_runner/context.py
+++ b/pipeline_runner/context.py
@@ -10,6 +10,7 @@ from slugify import slugify
 from . import utils
 from .config import DEFAULT_CACHES, DEFAULT_SERVICES
 from .models import (
+    CacheType,
     CloneSettings,
     Image,
     Pipeline,
@@ -31,7 +32,7 @@ class PipelineRunContext:
         self,
         pipeline_name: str,
         pipeline: Pipeline,
-        caches: dict[str, str],
+        caches: dict[str, CacheType],
         services: dict[str, Service],
         clone_settings: CloneSettings,
         default_image: Image | None,
@@ -127,7 +128,7 @@ class PipelineRunContext:
         return services
 
     @staticmethod
-    def _merge_default_caches(caches: Mapping[str, str]) -> dict[str, str]:
+    def _merge_default_caches(caches: Mapping[str, CacheType]) -> dict[str, CacheType]:
         all_caches = DEFAULT_CACHES.copy()
         all_caches.update(caches)
 

--- a/pipeline_runner/errors.py
+++ b/pipeline_runner/errors.py
@@ -13,6 +13,6 @@ class NegativeIntegerError(ValueError):
         super().__init__("value must be a positive integer")
 
 
-class UnsupportedCacheError(ValueError):
+class InvalidCacheKeyError(ValueError):
     def __init__(self, name: str) -> None:
-        super().__init__(f"Custom caches are not supported: {name}")
+        super().__init__(f'Cache "{name}": Cache key files could not be found')

--- a/pipeline_runner/errors.py
+++ b/pipeline_runner/errors.py
@@ -11,3 +11,8 @@ class InvalidServiceError(ValueError):
 class NegativeIntegerError(ValueError):
     def __init__(self) -> None:
         super().__init__("value must be a positive integer")
+
+
+class UnsupportedCacheError(ValueError):
+    def __init__(self, name: str) -> None:
+        super().__init__(f"Custom caches are not supported: {name}")

--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -92,10 +92,22 @@ class Service(BaseModel):
             self.variables[k] = Template(v).substitute(variables)
 
 
+class CacheKey(BaseModel):
+    files: list[str]
+
+
+class Cache(BaseModel):
+    key: CacheKey
+    path: str
+
+
+CacheType = Cache | str
+
+
 class Definitions(BaseModel):
     model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
-    caches: dict[str, str] = Field(default_factory=dict)
+    caches: dict[str, CacheType] = Field(default_factory=dict)
     services: dict[str, Service] = Field(default_factory=dict)
 
     @field_validator("services")
@@ -366,7 +378,7 @@ class PipelineSpec(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
     @property
-    def caches(self) -> dict[str, str]:
+    def caches(self) -> dict[str, CacheType]:
         return self.definitions.caches
 
     @property

--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -100,6 +100,9 @@ class Cache(BaseModel):
     key: CacheKey
     path: str
 
+    def __hash__(self) -> int:
+        return (*self.key.files, self.path).__hash__()
+
 
 CacheType = Cache | str
 

--- a/pipeline_runner/runner.py
+++ b/pipeline_runner/runner.py
@@ -342,7 +342,10 @@ class StepRunner(BaseStepRunner):
             raise Exception("called on uninitialized runner")
 
         cm = CacheManager(
-            self._container_runner, self._ctx.pipeline_ctx.get_cache_directory(), self._ctx.pipeline_ctx.caches
+            self._container_runner,
+            self._ctx.pipeline_ctx.repository,
+            self._ctx.pipeline_ctx.get_cache_directory(),
+            self._ctx.pipeline_ctx.caches,
         )
         cm.upload(self._step.caches)
 
@@ -379,6 +382,7 @@ class StepRunner(BaseStepRunner):
         if exit_code == 0:
             cm = CacheManager(
                 self._container_runner,
+                self._ctx.pipeline_ctx.repository,
                 self._ctx.pipeline_ctx.get_cache_directory(),
                 self._ctx.pipeline_ctx.caches,
             )

--- a/tests/integration/test_pipelines.py
+++ b/tests/integration/test_pipelines.py
@@ -176,6 +176,13 @@ def test_invalid_cache(project_cache_directory: Path) -> None:
     assert len(os.listdir(project_cache_directory)) == 0
 
 
+def test_custom_cache() -> None:
+    runner = PipelineRunner(PipelineRunRequest("custom.test_custom_cache"))
+    result = runner.run()
+
+    assert not result.ok
+
+
 def test_artifacts(artifacts_directory: Path) -> None:
     runner = PipelineRunner(PipelineRunRequest("custom.test_artifacts"))
     result = runner.run()

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -10,6 +10,18 @@ from pytest_mock import MockerFixture
 
 from pipeline_runner.cache import CacheSave, get_local_cache_archive_path
 from pipeline_runner.container import ContainerRunner
+from pipeline_runner.errors import UnsupportedCacheError
+from pipeline_runner.models import Cache
+
+
+def test_custom_caches_are_not_supported() -> None:
+    container = Mock(ContainerRunner)
+    cache_directory = "some-directory"
+    cache_name = "some-cache"
+    cache_definitions = {cache_name: Mock(Cache)}
+
+    with pytest.raises(UnsupportedCacheError, match=f"Custom caches are not supported: {cache_name}"):
+        CacheSave(container, cache_directory, cache_definitions, cache_name)
 
 
 def test_cache_is_created_if_it_does_not_exist(tmp_path: Path, mocker: MockerFixture, faker: Faker) -> None:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -8,24 +9,15 @@ from _pytest.logging import LogCaptureFixture
 from faker import Faker
 from pytest_mock import MockerFixture
 
-from pipeline_runner.cache import CacheSave, get_local_cache_archive_path
+from pipeline_runner.cache import CacheSave, compute_cache_key, get_local_cache_archive_path
 from pipeline_runner.container import ContainerRunner
-from pipeline_runner.errors import UnsupportedCacheError
-from pipeline_runner.models import Cache
-
-
-def test_custom_caches_are_not_supported() -> None:
-    container = Mock(ContainerRunner)
-    cache_directory = "some-directory"
-    cache_name = "some-cache"
-    cache_definitions = {cache_name: Mock(Cache)}
-
-    with pytest.raises(UnsupportedCacheError, match=f"Custom caches are not supported: {cache_name}"):
-        CacheSave(container, cache_directory, cache_definitions, cache_name)
+from pipeline_runner.errors import InvalidCacheKeyError
+from pipeline_runner.models import Cache, CacheKey, Repository
 
 
 def test_cache_is_created_if_it_does_not_exist(tmp_path: Path, mocker: MockerFixture, faker: Faker) -> None:
     container = Mock(ContainerRunner)
+    repository = Mock(Repository)
     cache_name = faker.pystr()
     cache_definitions = {cache_name: faker.file_path(extension="")}
 
@@ -34,7 +26,7 @@ def test_cache_is_created_if_it_does_not_exist(tmp_path: Path, mocker: MockerFix
     prepare_mock = mocker.patch.object(CacheSave, "_prepare")
     download_mock = mocker.patch.object(CacheSave, "_download")
 
-    saver = CacheSave(container, tmp_path.as_posix(), cache_definitions, cache_name)
+    saver = CacheSave(container, repository, tmp_path.as_posix(), cache_definitions, cache_name)
     saver.save()
 
     prepare_mock.assert_called_once()
@@ -59,6 +51,7 @@ def test_cache_is_updated_if_it_is_older_than_a_week(
     should_update: bool,
 ) -> None:
     container = Mock(ContainerRunner)
+    repository = Mock(Repository)
     cache_name = faker.pystr()
     cache_definitions = {cache_name: faker.file_path(extension="")}
 
@@ -71,7 +64,7 @@ def test_cache_is_updated_if_it_is_older_than_a_week(
     prepare_mock = mocker.patch.object(CacheSave, "_prepare")
     download_mock = mocker.patch.object(CacheSave, "_download")
 
-    saver = CacheSave(container, tmp_path.as_posix(), cache_definitions, cache_name)
+    saver = CacheSave(container, repository, tmp_path.as_posix(), cache_definitions, cache_name)
     saver.save()
 
     if should_update:
@@ -84,3 +77,90 @@ def test_cache_is_updated_if_it_is_older_than_a_week(
         download_mock.assert_not_called()
 
         assert f"You already have a '{cache_name}' cache" in caplog.text
+
+
+def test_compute_cache_key_for_regular_cache(faker: Faker) -> None:
+    repository = Mock(Repository)
+    cache_name = faker.pystr()
+    cache = faker.pystr()
+
+    assert compute_cache_key(cache_name, cache, repository) == cache_name
+
+
+def test_compute_cache_key_for_custom_cache(tmp_path: Path, faker: Faker) -> None:
+    repository = Mock(Repository, path=tmp_path.as_posix())
+    cache_name = faker.pystr()
+
+    file1_content = faker.pystr()
+    file1 = tmp_path / faker.pystr()
+    file1.write_text(file1_content)
+
+    file2_content = faker.pystr()
+    file2 = tmp_path / faker.pystr()
+    file2.write_text(file2_content)
+
+    cache = Cache(
+        key=CacheKey(files=[file1.as_posix(), file2.as_posix()]),
+        path=faker.file_path(extension=""),
+    )
+
+    hasher = hashlib.sha256()
+    hasher.update(file1_content.encode("utf-8"))
+    hasher.update(file2_content.encode("utf-8"))
+    expected_hash = hasher.hexdigest()
+
+    assert compute_cache_key(cache_name, cache, repository) == f"{cache_name}-{expected_hash}"
+
+
+def test_compute_cache_key_for_custom_cache_is_computed_only_once(tmp_path: Path, faker: Faker) -> None:
+    repository = Mock(Repository, path=tmp_path.as_posix())
+    cache_name = faker.pystr()
+
+    file1_content = faker.pystr()
+    file1 = tmp_path / faker.pystr()
+    file1.write_text(file1_content)
+
+    cache = Cache(
+        key=CacheKey(files=[file1.as_posix()]),
+        path=faker.file_path(extension=""),
+    )
+
+    key = compute_cache_key(cache_name, cache, repository)
+
+    file1.unlink()
+
+    # Should use the pre-computed value and ignore the fact that the file was deleted
+    assert compute_cache_key(cache_name, cache, repository) == key
+
+
+def test_compute_cache_key_for_custom_cache_ignores_non_existing_files(tmp_path: Path, faker: Faker) -> None:
+    repository = Mock(Repository, path=tmp_path.as_posix())
+    cache_name = faker.pystr()
+
+    file_content = faker.pystr()
+    file = tmp_path / faker.pystr()
+    file.write_text(file_content)
+
+    cache = Cache(
+        key=CacheKey(files=[faker.pystr(), file.as_posix(), faker.pystr()]),
+        path=faker.file_path(extension=""),
+    )
+
+    hasher = hashlib.sha256()
+    hasher.update(file_content.encode("utf-8"))
+    expected_hash = hasher.hexdigest()
+
+    assert compute_cache_key(cache_name, cache, repository) == f"{cache_name}-{expected_hash}"
+
+
+def test_compute_cache_key_for_custom_cache_fails_if_all_files_are_invalid(tmp_path: Path, faker: Faker) -> None:
+    repository = Mock(Repository, path=tmp_path.as_posix())
+    cache_name = faker.pystr()
+
+    cache = Cache(
+        key=CacheKey(files=[faker.pystr()]),
+        path=faker.file_path(extension=""),
+    )
+
+    with pytest.raises(InvalidCacheKeyError, match=f'Cache "{cache_name}": Cache key files could not be found'):
+        compute_cache_key(cache_name, cache, repository)


### PR DESCRIPTION
Add support for caches defined like such:

```yaml
definitions:
  caches:
    my-bundler-cache:
      key:
        files:
          - Gemfile.lock
          - "**/*.gemspec" # glob patterns are supported for cache key files
      path: vendor/bundle
```

Drive-by: Fix issue with `[[` test in the `_deps` just recipe