### PR TITLE
Add missing files for ssh and missing mounts for pipes

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -329,7 +329,14 @@ pipelines:
               ServerAliveInterval 180
               EOF
             - test "$(sha256sum /tmp/ssh-conf | cut -d ' ' -f 1)" == "$(sha256sum ~/.ssh/config | cut -d ' ' -f 1)"
+
             - ssh-keygen -l -f /opt/atlassian/pipelines/agent/ssh/id_rsa
+            - test "$(stat -c '%a' /opt/atlassian/pipelines/agent/ssh/id_rsa)" == "600"
+
+            - |-
+              test "$(sha256sum /opt/atlassian/pipelines/agent/ssh/id_rsa | cut -d ' ' -f 1)" \
+                == "$(sha256sum /opt/atlassian/pipelines/agent/ssh/id_rsa_tmp | cut -d ' ' -f 1)"
+            - test "$(stat -c '%a' /opt/atlassian/pipelines/agent/ssh/id_rsa_tmp)" == "644"
           artifacts:
             - variables
 

--- a/pipeline_runner/container.py
+++ b/pipeline_runner/container.py
@@ -216,6 +216,7 @@ class ContainerRunner:
             return
 
         private_key_file_path = os.path.join(config.ssh_key_dir, "id_rsa")
+        known_hosts_file_path = os.path.join(config.ssh_key_dir, "known_hosts")
 
         cmd = " && ".join(
             [
@@ -223,6 +224,9 @@ class ContainerRunner:
                 f'echo "IdentityFile {private_key_file_path}\nServerAliveInterval 180" > ~/.ssh/config',
                 f"install -m 600 /dev/null {private_key_file_path}",
                 f'echo "{self._ssh_private_key}" > {private_key_file_path}',
+                # The default ssh key with open perms readable by alt uids
+                f"install -m 644 {private_key_file_path} {private_key_file_path}_tmp",
+                f"install -m 644 /dev/null {known_hosts_file_path}",
             ]
         )
         exit_code, output = self.run_command(cmd, user=0)

--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -200,13 +200,22 @@ class Pipe(BaseModel):
     variables: dict[str, str | list[str]] = Field(default_factory=dict)
 
     def as_cmd(self) -> str:
-        cmd = "docker run --rm"
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "--volume=/opt/atlassian/pipelines/agent/build:/opt/atlassian/pipelines/agent/build",
+            "--volume=/opt/atlassian/pipelines/agent/ssh:/opt/atlassian/pipelines/agent/ssh:ro",
+            "--volume=/opt/atlassian/pipelines/bin/docker:/usr/local/bin/docker:ro",
+        ]
 
         variables = self.expand_variables()
         if variables:
-            cmd += " " + " ".join(f'-e {k}="{self._escape_value(v)}"' for k, v in variables.items())
+            cmd += [f'-e {k}="{self._escape_value(v)}"' for k, v in variables.items()]
 
-        return f"{cmd} {self.get_image()}"
+        cmd.append(self.get_image())
+
+        return " ".join(cmd)
 
     def expand_variables(self) -> dict[str, str]:
         expanded_variables = {}

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -94,6 +94,9 @@ def test_pipe_as_cmd_transforms_the_pipe_into_a_docker_command() -> None:
 
     assert p.as_cmd() == (
         "docker run --rm "
+        "--volume=/opt/atlassian/pipelines/agent/build:/opt/atlassian/pipelines/agent/build "
+        "--volume=/opt/atlassian/pipelines/agent/ssh:/opt/atlassian/pipelines/agent/ssh:ro "
+        "--volume=/opt/atlassian/pipelines/bin/docker:/usr/local/bin/docker:ro "
         '-e FOO="BAR" '
         '-e BAZ="[{\\"some\\": \\"json with \'single-quotes\'\\", \\"more\\": \\"json with line\nbreak\\"}]" '
         '-e ENV="${SOME_ENVVAR}" '


### PR DESCRIPTION
A few files were missing to replicate Bitbucket's ssh configuration.
1. The `known_hosts` was not generated. It is not generated as an empty file. Some default host keys will probably be added in the future.
2. The `id_rsa_tmp` key file was not generated. It is the same as `id_rsa`, but with world access. #SeKuRtY

Some mounts were also missing for pipes, most importantly the ssh folder. They are now mounted properly.