### PR TITLE
Fix error when cloning the repository if origin ownership differs

### DIFF
--- a/pipeline_runner/repository.py
+++ b/pipeline_runner/repository.py
@@ -54,6 +54,12 @@ class RepositoryCloner:
         runner.start()
 
         try:
+            exec_result = runner.run_command(
+                f"git config --system --add safe.directory '{config.remote_workspace_dir}/.git'", user=0
+            )
+            if exec_result.exit_code:
+                raise Exception("Error setting up repository")
+
             clone_script = self._get_clone_script()
             exit_code = runner.run_script(clone_script)
 


### PR DESCRIPTION
Since git v2.43.4, the default behavior is to refuse to clone if the origin's ownership differs from the user doing the cloning.

Since the user running this program (hopefully) trusts the repository, we can simply tell git that the origin repository can be considered safe.

Fixes #22 