### PR TITLE
Add support for `tags` and `bookmark` pipelines

### DIFF
--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -379,6 +379,8 @@ class Pipelines(BaseModel):
     branches: dict[str, Pipeline] = Field(default_factory=dict)
     pull_requests: dict[str, Pipeline] = Field(default_factory=dict, alias="pull-requests")
     custom: dict[str, Pipeline] = Field(default_factory=dict)
+    tags: dict[str, Pipeline] = Field(default_factory=dict)
+    bookmarks: dict[str, Pipeline] = Field(default_factory=dict)
 
     def get_all(self) -> dict[str, Pipeline]:
         pipelines = {}

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -579,6 +579,8 @@ def test_parse_pipeline_with_env_vars() -> None:
             "branches": {},
             "pull-requests": {},
             "custom": {},
+            "tags": {},
+            "bookmarks": {},
         },
     }
 


### PR DESCRIPTION
The bitbucket-pipelines.yml spec allows the following tags under `pipeline`: `default`, `branches`, `tags`, `bookmarks`, `custom` and `pull-requests`. Out of those, `tags` and `bookmarks` were not supported. 

This PR adds support for those two missing tags.

Fixes #26