### PR TITLE
chore: Update docker service to latest version

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -354,7 +354,8 @@ pipelines:
             - |
               cat << EOF > Dockerfile
               FROM alpine
-              RUN apk --no-cache add bash
+              RUN --mount=type=cache,target=/var/cache/apk \
+                  apk add bash
               ENTRYPOINT ["bash"]
               EOF
             - DOCKER_BUILDKIT=1 docker build -t buildtest .

--- a/pipeline_runner/config.py
+++ b/pipeline_runner/config.py
@@ -31,12 +31,16 @@ DEFAULT_SERVICES: Mapping[str, Any] = MappingProxyType(
         "docker": {
             "image": (
                 "docker-public.packages.atlassian.com/sox/atlassian"
-                "/bitbucket-pipelines-docker-daemon:v20.10.24-multiarch-prod-stable"
+                "/bitbucket-pipelines-docker-daemon:v25.0.3-prod-stable"
             ),
             "memory": 1024,
         }
     }
 )
+
+# This is the version of the client that is injected in the container if docker is not already present.
+# It is _not_ the same as the docker daemon version.
+ATLASSIAN_DOCKER_CLI_VERSION = "20.10.24"
 
 
 class Config(BaseSettings):

--- a/pipeline_runner/service.py
+++ b/pipeline_runner/service.py
@@ -138,6 +138,8 @@ class ServiceRunner:
         pull_image(self._client, self._service.image)
 
         self._container = self._start_container()
+
+        logger.info("Waiting for service to be ready: %s", self._service_name)
         self._ensure_container_ready(self._container)
 
     def _start_container(self) -> Container:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,8 +73,6 @@ ignore = [
     "PTH",  # flake8-use-pathlib
     "TD",  # flake8-todos
 
-    "ANN101",  # Missing type annotation for `self` in method
-    "ANN102",  # Missing type annotation for `cls` in classmethod
     "EM101",  # Exception must not use a string literal, assign to variable first
     "EM102",  # Exception must not use an f-string literal, assign to variable first
     "PLR0913",  # Too many arguments to function call

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -99,7 +99,7 @@ def test_docker_is_added_to_services_if_not_present(project_metadata: ProjectMet
     docker_service = Service(
         image=Image(
             name="docker-public.packages.atlassian.com/sox/atlassian"
-            "/bitbucket-pipelines-docker-daemon:v20.10.24-multiarch-prod-stable"
+            "/bitbucket-pipelines-docker-daemon:v25.0.3-prod-stable"
         ),
         variables={},
         memory=1024,
@@ -125,7 +125,7 @@ def test_docker_service_uses_fallback_values(project_metadata: ProjectMetadata) 
     docker_service = Service(
         image=Image(
             name="docker-public.packages.atlassian.com/sox/atlassian"
-            "/bitbucket-pipelines-docker-daemon:v20.10.24-multiarch-prod-stable"
+            "/bitbucket-pipelines-docker-daemon:v25.0.3-prod-stable"
         ),
         variables={"FOO": "bar"},
         memory=2048,


### PR DESCRIPTION
Update the docker service to version 25.0.3, to be in sync with the version used by Bitbucket Pipelines. Strangely, the version of the cli they inject if needed is not the same, it is actually 20.10.24. The injected docker cli was changed to match this version. The sha256 sum of the injected docker cli was validated to ensure it matches the one they inject.

The test for docker buildkit was also updated to actually require buildkit, for added assurance.

Drive-by: Remove un-necessary ignored ruff rules. Those rules have been removed from ruff.