### PR TITLE
fix: Parallel entry with only one step is valid

### DIFF
--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -304,7 +304,7 @@ class StepWrapper(BaseModel):
 
 
 class ParallelStep(ListWrapper[StepWrapper]):
-    wrapped: list[StepWrapper] = Field(alias="parallel", min_length=2)
+    wrapped: list[StepWrapper] = Field(alias="parallel", min_length=1)
 
     def expand_env_vars(self, variables: dict[str, str]) -> None:
         for s in self.wrapped:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -82,14 +82,14 @@ def test_cache_supports_custom_keys() -> None:
     }
 
 
-@pytest.mark.parametrize(("num_items", "is_valid"), [(0, False), (1, False), (2, True)])
-def test_parallel_step_must_contain_at_least_2_items(num_items: int, is_valid: bool) -> None:
+@pytest.mark.parametrize(("num_items", "is_valid"), [(0, False), (1, True), (2, True)])
+def test_parallel_step_must_contain_at_least_1_item(num_items: int, is_valid: bool) -> None:
     spec: dict[str, Any] = {"parallel": [{"step": {"script": []}} for _ in range(num_items)]}
 
     if is_valid:
         ParallelStep.model_validate(spec)
     else:
-        with pytest.raises(ValidationError, match="List should have at least 2 items after validation"):
+        with pytest.raises(ValidationError, match="List should have at least 1 item after validation"):
             ParallelStep.model_validate(spec)
 
 


### PR DESCRIPTION
Change the validation on parallel step to allow a minimum of one step.