### PR TITLE
fix: Allow `steps` key under `parallel`

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -298,6 +298,20 @@ pipelines:
               - set -eu
               - '[ "${BITBUCKET_PARALLEL_STEP}" = 1 ]'
               - '[ "${BITBUCKET_PARALLEL_STEP_COUNT}" = 2 ]'
+      - parallel:
+          steps:
+            - step:
+                name: Step 1 of 2
+                script:
+                  - set -eu
+                  - '[ "${BITBUCKET_PARALLEL_STEP}" = 0 ]'
+                  - '[ "${BITBUCKET_PARALLEL_STEP_COUNT}" = 2 ]'
+            - step:
+                name: Step 2 of 2
+                script:
+                  - set -eu
+                  - '[ "${BITBUCKET_PARALLEL_STEP}" = 1 ]'
+                  - '[ "${BITBUCKET_PARALLEL_STEP_COUNT}" = 2 ]'
 
     test_environment_variables:
       - step:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -15,6 +15,7 @@ from pipeline_runner.models import (
     CacheKey,
     Definitions,
     ParallelStep,
+    ParallelSteps,
     Pipe,
     Pipeline,
     PipelineResult,
@@ -83,13 +84,24 @@ def test_cache_supports_custom_keys() -> None:
 
 
 @pytest.mark.parametrize(("num_items", "is_valid"), [(0, False), (1, True), (2, True)])
+def test_parallel_steps_must_contain_at_least_1_item(num_items: int, is_valid: bool) -> None:
+    spec: dict[str, Any] = {"steps": [{"step": {"script": []}} for _ in range(num_items)]}
+
+    if is_valid:
+        ParallelSteps.model_validate(spec)
+    else:
+        with pytest.raises(ValidationError, match="List should have at least 1 item after validation"):
+            ParallelSteps.model_validate(spec)
+
+
+@pytest.mark.parametrize(("num_items", "is_valid"), [(0, False), (1, True), (2, True)])
 def test_parallel_step_must_contain_at_least_1_item(num_items: int, is_valid: bool) -> None:
     spec: dict[str, Any] = {"parallel": [{"step": {"script": []}} for _ in range(num_items)]}
 
     if is_valid:
         ParallelStep.model_validate(spec)
     else:
-        with pytest.raises(ValidationError, match="List should have at least 1 item after validation"):
+        with pytest.raises(ValidationError, match="Value should have at least 1 item after validation"):
             ParallelStep.model_validate(spec)
 
 

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -11,6 +11,7 @@ from pipeline_runner.models import (
     Definitions,
     Image,
     ParallelStep,
+    ParallelSteps,
     Pipe,
     Pipeline,
     Pipelines,
@@ -245,6 +246,14 @@ def test_parse_pipeline_with_parallel_steps() -> None:
                 {"step": {"name": "Parallel Step 2", "script": ["echo 'Parallel 2'"]}},
             ]
         },
+        {
+            "parallel": {
+                "steps": [
+                    {"step": {"name": "Parallel Step 3", "script": ["echo 'Parallel 3'"]}},
+                    {"step": {"name": "Parallel Step 4", "script": ["echo 'Parallel 4'"]}},
+                ]
+            }
+        },
     ]
 
     pipeline = Pipeline.model_validate(spec)
@@ -252,7 +261,15 @@ def test_parse_pipeline_with_parallel_steps() -> None:
     step1 = StepWrapper(step=Step(name="Step 1", script=["cat /etc/os-release", "exit 0"]))
     pstep1 = StepWrapper(step=Step(name="Parallel Step 1", script=["echo 'Parallel 1'"]))
     pstep2 = StepWrapper(step=Step(name="Parallel Step 2", script=["echo 'Parallel 2'"]))
-    expected = Pipeline(root=[step1, ParallelStep(wrapped=[pstep1, pstep2])])
+    pstep3 = StepWrapper(step=Step(name="Parallel Step 3", script=["echo 'Parallel 3'"]))
+    pstep4 = StepWrapper(step=Step(name="Parallel Step 4", script=["echo 'Parallel 4'"]))
+    expected = Pipeline(
+        root=[
+            step1,
+            ParallelStep(parallel=[pstep1, pstep2]),
+            ParallelStep(parallel=ParallelSteps(wrapped=[pstep3, pstep4])),
+        ]
+    )
 
     assert pipeline == expected
 


### PR DESCRIPTION
Parallel steps can be defined one of two ways:
```yaml
- parallel:
    - step:
        name: Step 1
        script:
          - echo "ok"
    - step:
        name: Step 2
        script:
          - echo "ok"
```
```yaml
- parallel:
    steps:
      - step:
          name: Step 1
          script:
            - echo "ok"
      - step:
          name: Step 2
          script:
            - echo "ok"
```

Only the first one was supported. This adds support for the second form.