### PR TITLE
feat: Allow overriding the docker platform for the pipeline container

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ container running the pipeline. If you have more than one ssh key linked to an
 account on the target git hosting, ensure that the one you need to use is the
 first one in the agent.
 
+## Alternate Platform
+To force a different plaform for the pipeline container, you can set the following environment variable:
+```shell
+# Replace linux/amd64 by the target platform
+export PIPELINE_RUNNER_DOCKER_PLATFORM=linux/amd64
+```
+
+Note that this affects _only_ the pipeline container, ie. the one that runs your script. It will not
+affect the services requested by the pipeline.
+
+If you are running on Apple Silicon, you can force docker to run _all_ containers on a different platform:
+```shell
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+```
+
+> [!WARNING]
+This feature is still experimental
+
 ## Debugging
 A few features are available to help with debugging.
 

--- a/pipeline_runner/container.py
+++ b/pipeline_runner/container.py
@@ -525,7 +525,7 @@ class RemoteActionManager:
 _pulled_images = set()
 
 
-def pull_image(client: DockerClient, image: Image, platform: str | None) -> None:
+def pull_image(client: DockerClient, image: Image, platform: str | None = None) -> None:
     if image.name in _pulled_images:
         logger.info("Image already pulled: %s", image.name)
         return


### PR DESCRIPTION
This can allow replicating Bitbucket Pipelines more accurately when running on Apple Silicon, by forcing the pipeline container to run with the amd64 platform.