### PR TITLE
feat: Add support for custom volumes

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -410,3 +410,15 @@ pipelines:
           oidc: true
           script:
             - "echo a"
+
+    test_user_defined_volumes:
+      - step:
+          name: Test custom volumes
+          script:
+            - test -d /custom-rw
+            - echo ok > /custom-rw/file
+
+            - test -d /custom-ro
+            - if echo ok > /custom-ro/file; then
+            -   exit 1
+            - fi

--- a/pipeline_runner/cli.py
+++ b/pipeline_runner/cli.py
@@ -86,19 +86,25 @@ def main(ctx: click.Context, *, show_version: bool) -> None:
 @click.option(
     "-c",
     "--color/--no-color",
-    default=True,
+    default=None,
     help="Enable colored output. Default: True",
 )
 @click.option(
     "--cpu-limits/--no-cpu-limits",
-    default=False,
+    default=None,
     help="Enable to enforce cpu limits for the runner. Default: False",
 )
 @click.option(
     "--ssh/--no-ssh",
     "expose_ssh_agent",
-    default=False,
+    default=None,
     help="Expose the local ssh agent to the container. Default: False",
+)
+@click.option(
+    "--volume",
+    "volumes",
+    multiple=True,
+    help="Extra volume mounts for the pipeline container. Supports docker --volume syntax.",
 )
 def run(
     pipeline: str | None,
@@ -109,15 +115,21 @@ def run(
     color: bool,
     cpu_limits: bool,
     expose_ssh_agent: bool,
+    volumes: tuple[str] | None,
 ) -> None:
     """
     Run the pipeline <PIPELINE>.
 
     PIPELINE is the full path to the pipeline to run. Ex: branches.master
     """
-    config.color = color
-    config.cpu_limits = cpu_limits
-    config.expose_ssh_agent = expose_ssh_agent
+    if color is not None:
+        config.color = color
+    if cpu_limits is not None:
+        config.cpu_limits = cpu_limits
+    if expose_ssh_agent is not None:
+        config.expose_ssh_agent = expose_ssh_agent
+    if volumes:
+        config.volumes = list(volumes)
 
     _init_logger()
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -17,7 +17,7 @@ from pipeline_runner.config import Config
         ("~/.cache:/cache:ro:wat", "invalid volume spec"),
     ],
 )
-def test_validate_volumes_conform_to_docker_spec(*, volume: str, expected_error: str | None):
+def test_validate_volumes_conform_to_docker_spec(*, volume: str, expected_error: str | None) -> None:
     if expected_error:
         with pytest.raises(ValidationError, match=expected_error):
             Config.model_validate({"volumes": [volume]})
@@ -25,7 +25,7 @@ def test_validate_volumes_conform_to_docker_spec(*, volume: str, expected_error:
         Config.model_validate({"volumes": [volume]})
 
 
-def test_validate_validates_all():
+def test_validate_validates_all_volumes() -> None:
     volumes = ["", "foo:x:y:z", "valid", "bar:x:y:z"]
 
     with pytest.raises(ValidationError) as exc_info:
@@ -47,7 +47,7 @@ def test_validate_validates_all():
         ),
     ],
 )
-def test_validate_expands_first_part(monkeypatch: MonkeyPatch, *, volume: str, expected: str):
+def test_validate_expands_first_part(monkeypatch: MonkeyPatch, *, volume: str, expected: str) -> None:
     monkeypatch.setenv("SOMEVAR", "expanded-var")
 
     c = Config.model_validate({"volumes": [volume]})

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,55 @@
+import os
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from pydantic import ValidationError
+
+from pipeline_runner.config import Config
+
+
+@pytest.mark.parametrize(
+    ("volume", "expected_error"),
+    [
+        ("~/.cache", None),
+        ("~/.cache:/cache", None),
+        ("~/.cache:/cache:ro", None),
+        ("", "empty volume spec"),
+        ("~/.cache:/cache:ro:wat", "invalid volume spec"),
+    ],
+)
+def test_validate_volumes_conform_to_docker_spec(*, volume: str, expected_error: str | None):
+    if expected_error:
+        with pytest.raises(ValidationError, match=expected_error):
+            Config.model_validate({"volumes": [volume]})
+    else:
+        Config.model_validate({"volumes": [volume]})
+
+
+def test_validate_validates_all():
+    volumes = ["", "foo:x:y:z", "valid", "bar:x:y:z"]
+
+    with pytest.raises(ValidationError) as exc_info:
+        Config.model_validate({"volumes": volumes})
+
+    assert "Invalid volume: : empty volume spec" in str(exc_info.value)
+    assert "Invalid volume: foo:x:y:z: invalid volume spec" in str(exc_info.value)
+    assert "Invalid volume: bar:x:y:z: invalid volume spec" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ("volume", "expected"),
+    [
+        ("~/.cache:~:~", f"{os.path.expanduser('~')}/.cache:~:~"),
+        ("${SOMEVAR}:${SOMEVAR}:${SOMEVAR}", "expanded-var:${SOMEVAR}:${SOMEVAR}"),
+        (
+            "~/${SOMEVAR}:~/${SOMEVAR}:~/${SOMEVAR}",
+            f"{os.path.expanduser('~')}/expanded-var:~/${{SOMEVAR}}:~/${{SOMEVAR}}",
+        ),
+    ],
+)
+def test_validate_expands_first_part(monkeypatch: MonkeyPatch, *, volume: str, expected: str):
+    monkeypatch.setenv("SOMEVAR", "expanded-var")
+
+    c = Config.model_validate({"volumes": [volume]})
+
+    assert c.volumes == [expected]


### PR DESCRIPTION
Add support for custom volume mounts in the runner container. This allows the user to mount arbitrary volumes in the runner container, allowing the use of local AWS credentials for example.