### PR TITLE
Add warning for ssh agent forwarding on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note: Docker cache is stored in a docker volume instead.
 
 ## SSH Agent Forwarding
 > [!WARNING]
-SSH Agent forwarding is only available on Linux and macOS
+SSH Agent forwarding is only available on Linux and macOS<br />
 See: https://docs.docker.com/desktop/features/networking/#ssh-agent-forwarding
 
 You can expose your ssh-agent to the container running the pipelines. This is useful if the pipeline needs to clone

--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ On macOS:
 Note: Docker cache is stored in a docker volume instead.
 
 ## SSH Agent Forwarding
+> [!WARNING]
+SSH Agent forwarding is only available on Linux and macOS
+See: https://docs.docker.com/desktop/features/networking/#ssh-agent-forwarding
+
 You can expose your ssh-agent to the container running the pipelines. This is useful if the pipeline needs to clone
-from a private repository for example.
+from a private repository, for example.
 To do so, run the pipeline with the `--ssh` flag:
 
 ```shell

--- a/tests/integration/test_pipelines.py
+++ b/tests/integration/test_pipelines.py
@@ -534,6 +534,21 @@ def test_pipeline_with_pipe(pipeline_data_directory: Path, project_path_slug: st
         assert any(i for i in log_lines if i == expected)
 
 
+def test_ssh_agent_forwarding(config: Config, monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    config.expose_ssh_agent = True
+
+    ssh_agent = tmp_path / "ssh_agent"
+    with ssh_agent.open("w") as f:
+        f.write("some-ssh-agent")
+
+    monkeypatch.setenv("SSH_AUTH_SOCK", str(ssh_agent))
+
+    runner = PipelineRunner(PipelineRunRequest("custom.test_ssh_agent"))
+    result = runner.run()
+
+    assert result.ok
+
+
 def test_ssh_key_is_present_in_runner() -> None:
     runner = PipelineRunner(PipelineRunRequest("custom.test_ssh_key"))
     result = runner.run()


### PR DESCRIPTION
SSH Agent forwarding is not available on Docker Desktop in Windows. Add a warning in the README explaining this and in the code if the user tries to use the `--ssh` option in Windows.