### PR TITLE
Allow ssh agent forwarding for docker within WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Note: Docker cache is stored in a docker volume instead.
 
 ## SSH Agent Forwarding
 > [!WARNING]
-SSH Agent forwarding is only available on Linux and macOS<br />
+SSH Agent forwarding is not available for Docker Desktop on Windows<br />
 See: https://docs.docker.com/desktop/features/networking/#ssh-agent-forwarding
 
 You can expose your ssh-agent to the container running the pipelines. This is useful if the pipeline needs to clone


### PR DESCRIPTION
SSH agent forwarding is possible in WSL, as long as docker is running _inside_ the WSL instance. Relax the check to allow for this scenario.