### PR TITLE
Add support for output variables

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -424,3 +424,56 @@ pipelines:
             - if echo ok > /custom-ro/file; then
             -   exit 1
             - fi
+
+    test_output_variables:
+      - step:
+          name: Variables A
+          script:
+            - echo "${BITBUCKET_PIPELINES_VARIABLES_PATH:?not set}"
+
+            - if [ ! -e "${BITBUCKET_PIPELINES_VARIABLES_PATH}" ]; then
+            -   echo "File '${BITBUCKET_PIPELINES_VARIABLES_PATH}' does not exist"
+            -   exit 1
+            - fi
+
+            - echo "STEP_A_VAR_1=step-a-value-1" >> $BITBUCKET_PIPELINES_VARIABLES_PATH
+            - echo "STEP_A_VAR_2=step-a-value-2" >> $BITBUCKET_PIPELINES_VARIABLES_PATH
+          output-variables:
+            - STEP_A_VAR_1
+            - STEP_A_VAR_2
+            - STEP_A_VAR_3  # Unused
+      - step:
+          name: Variables B
+          script:
+            - echo "${BITBUCKET_PIPELINES_VARIABLES_PATH:?not set}"
+
+            - if [ ! -e "${BITBUCKET_PIPELINES_VARIABLES_PATH}" ]; then
+            -   echo "File '${BITBUCKET_PIPELINES_VARIABLES_PATH}' does not exist"
+            -   exit 1
+            - fi
+
+            # Those should be defined from the previous step
+            - test "${STEP_A_VAR_1:-}" = "step-a-value-1"
+            - test "${STEP_A_VAR_2:-}" = "step-a-value-2"
+
+            - echo "STEP_B_VAR_1=step-b-value-1" >> $BITBUCKET_PIPELINES_VARIABLES_PATH
+          output-variables:
+            - STEP_B_VAR_1
+      - step:
+          name: Validate Variables
+          script:
+            # The variable should still be set
+            - echo "${BITBUCKET_PIPELINES_VARIABLES_PATH:?not set}"
+
+            # But the file should not exist
+            - if [ -e "${BITBUCKET_PIPELINES_VARIABLES_PATH}" ]; then
+            -   echo "File '${BITBUCKET_PIPELINES_VARIABLES_PATH}' should not exist"
+            -   exit 1
+            - fi
+
+            # Those should be defined from the first step
+            - test "${STEP_A_VAR_1:-}" = "step-a-value-1"
+            - test "${STEP_A_VAR_2:-}" = "step-a-value-2"
+
+            # Those should be defined from the previous step
+            - test "${STEP_B_VAR_1:-}" = "step-b-value-1"

--- a/pipeline_runner/config.py
+++ b/pipeline_runner/config.py
@@ -73,7 +73,7 @@ class Config(BaseSettings):
     remote_pipeline_dir: str = "/opt/atlassian/pipelines/agent"
     build_dir: str = "/opt/atlassian/pipelines/agent/build"
     scripts_dir: str = "/opt/atlassian/pipelines/agent/scripts"
-    temp_dir: str = "/opt/atlassian/pipelines/agent/temp"
+    temp_dir: str = "/opt/atlassian/pipelines/agent/tmp"
     caches_dir: str = "/opt/atlassian/pipelines/agent/caches"
     ssh_key_dir: str = "/opt/atlassian/pipelines/agent/ssh"
 

--- a/pipeline_runner/container.py
+++ b/pipeline_runner/container.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from importlib.resources import as_file, files
 from io import BufferedReader
 from logging import Logger
+from pathlib import Path
 from time import time
 from typing import Any, TypedDict, cast
 
@@ -49,6 +50,7 @@ class ContainerRunner:
         env_vars: dict[str, str],
         output_logger: Logger,
         mem_limit: int = 512,
+        pipeline_variables_file: Path | None = None,
     ) -> None:
         self._ctx = ctx
         self._name = name
@@ -59,6 +61,7 @@ class ContainerRunner:
         self._environment = env_vars
         self._logger = output_logger
         self._mem_limit = mem_limit * 2**20  # MiB to B
+        self._pipeline_variables_file = pipeline_variables_file
         self._ssh_private_key = ctx.pipeline_ctx.project_metadata.ssh_key
         self._platform = os.getenv("PIPELINE_RUNNER_DOCKER_PLATFORM")
 
@@ -266,6 +269,8 @@ class ContainerRunner:
                 self._data_volume_name: {"bind": config.remote_pipeline_dir},
             }
         )
+        if self._pipeline_variables_file is not None:
+            volumes[str(self._pipeline_variables_file)] = {"bind": f"{config.temp_dir}/pipeline-variables.env"}
 
         return volumes
 

--- a/pipeline_runner/errors.py
+++ b/pipeline_runner/errors.py
@@ -47,3 +47,15 @@ class InvalidCacheKeyError(ValueError):
 class ArtifactManagementError(Exception):
     def __init__(self, msg: str) -> None:
         super().__init__(msg)
+
+
+class InvalidOutputVariablesError(UsageError):
+    def __init__(self, invalid_variables: set[str]) -> None:
+        if len(invalid_variables) == 1:
+            var = invalid_variables.pop()
+            msg = f"The {var} variable is not defined in the output variables. Define this output variable."
+        else:
+            var_names = ", ".join(invalid_variables)
+            msg = f"The {var_names} variables are not defined in the output variables. Define these output variables."
+
+        super().__init__(msg)

--- a/pipeline_runner/errors.py
+++ b/pipeline_runner/errors.py
@@ -50,6 +50,11 @@ class ArtifactManagementError(Exception):
 
 
 class InvalidOutputVariablesError(UsageError):
+    def __init__(self, invalid_variable: str) -> None:
+        super().__init__(f"Invalid variable format: {invalid_variable}")
+
+
+class UndefinedOutputVariablesError(UsageError):
     def __init__(self, invalid_variables: set[str]) -> None:
         if len(invalid_variables) == 1:
             var = invalid_variables.pop()

--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -326,6 +326,7 @@ class Step(BaseModel):
     max_time: int | None = Field(None, alias="max-time")
     condition: Condition | None = None
     oidc: bool = False
+    output_variables: list[str] = Field(default_factory=list, alias="output-variables")
 
     __env_var_expand_fields__: Sequence[str] = ["image"]
 

--- a/pipeline_runner/runner.py
+++ b/pipeline_runner/runner.py
@@ -148,8 +148,9 @@ class StepRunner(BaseStepRunner):
 
     # TODO: Decomplexify
     # C901: Too complex (>10)
+    # PLR0912: Too many branches (>12)
     # PLR0915: Too many statements (>50)
-    def run(self) -> int | None:  # noqa: C901, PLR0915
+    def run(self) -> int | None:  # noqa: C901, PLR0912, PLR0915
         if not self._should_run():
             logger.info("Skipping step: %s", self._step.name)
             return None
@@ -453,22 +454,22 @@ class StepRunner(BaseStepRunner):
         # TODO: Remove
         pass
 
-    def _extract_output_variables(self):
+    def _extract_output_variables(self) -> None:
         if not self._pipeline_variables_file:
             return
 
         values = dotenv.dotenv_values(self._pipeline_variables_file)
 
         # TODO: Validate invalid format
-        # TODO: What about `FOO=`?
 
         invalid_keys = values.keys() - set(self._step.output_variables)
         if invalid_keys:
             raise InvalidOutputVariablesError(invalid_keys)
 
-        values
+        # Bitbucket ignores variables with no values, but only after first validating the keys
+        valid_values = {k: v for k, v in values.items() if v is not None}
 
-        self._ctx.pipeline_ctx.pipeline_variables.update(values)
+        self._ctx.pipeline_ctx.pipeline_variables.update(valid_values)
 
 
 class ParallelStepRunner(BaseStepRunner):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ classmethod-decorators = [
     "PLR2004", # Magic value used in comparison
     "S101", # Use of `assert` detected
     "S105", # Possible hardcoded password
+    "SLF001", # Private member accessed: Acceptable until a refactor
 ]
 
 [tool.pytest.ini_options]

--- a/tests/integration/test_pipelines.py
+++ b/tests/integration/test_pipelines.py
@@ -438,6 +438,7 @@ def test_environment_variables(
         "BITBUCKET_REPO_UUID": str(project_metadata.repo_uuid),
         "BITBUCKET_STEP_UUID": str(step_uuid),
         "BITBUCKET_WORKSPACE": slug,
+        "BITBUCKET_PIPELINES_VARIABLES_PATH": "/opt/atlassian/pipelines/agent/tmp/pipeline-variables.env",
         "BUILD_DIR": "/opt/atlassian/pipelines/agent/build",
         "CI": "true",
     }

--- a/tests/integration/test_pipelines.py
+++ b/tests/integration/test_pipelines.py
@@ -639,6 +639,13 @@ def test_user_defined_volumes(tmp_path: Path, config: Config) -> None:
     assert not (custom_ro / "file").exists()
 
 
+def test_output_variables() -> None:
+    runner = PipelineRunner(PipelineRunRequest("custom.test_output_variables"))
+    result = runner.run()
+
+    assert result.ok
+
+
 def _sha256hash(data: bytes) -> str:
     hasher = hashlib.sha256()
     hasher.update(data)

--- a/tests/unit/test_parse.py
+++ b/tests/unit/test_parse.py
@@ -559,6 +559,7 @@ def test_parse_pipeline_with_env_vars() -> None:
                         "max-time": None,
                         "condition": None,
                         "oidc": False,
+                        "output-variables": [],
                     },
                 },
                 {
@@ -589,6 +590,7 @@ def test_parse_pipeline_with_env_vars() -> None:
                                 "max-time": None,
                                 "condition": None,
                                 "oidc": False,
+                                "output-variables": [],
                             }
                         },
                         {
@@ -617,6 +619,7 @@ def test_parse_pipeline_with_env_vars() -> None:
                                 "max-time": None,
                                 "condition": None,
                                 "oidc": False,
+                                "output-variables": [],
                             }
                         },
                     ],

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -1,0 +1,180 @@
+from collections.abc import Generator
+from logging import Logger
+from pathlib import Path
+
+import pytest
+from click import UsageError
+from docker import DockerClient  # type: ignore[import-untyped]
+from faker.proxy import Faker
+from pytest_mock import MockerFixture
+
+from pipeline_runner.runner import StepRunner
+
+
+@pytest.fixture(autouse=True)
+def docker_client(mocker: MockerFixture) -> Generator[DockerClient]:
+    mock_client = mocker.Mock()
+    with mocker.patch("pipeline_runner.runner.docker.from_env", return_value=mock_client):
+        yield mock_client
+
+
+@pytest.fixture(autouse=True)
+def output_logger(mocker: MockerFixture) -> Generator[Logger]:
+    mock_logger = mocker.Mock()
+    with mocker.patch("pipeline_runner.runner.utils.get_output_logger", return_value=mock_logger):
+        yield mock_logger
+
+
+def test_step_runner_extract_output_variables(mocker: MockerFixture, faker: Faker, tmp_path: Path) -> None:
+    var1 = faker.pystr()
+    value1 = faker.pystr()
+    var2 = faker.pystr()
+    value2 = faker.pystr()
+    var3 = faker.pystr()
+
+    existing_var1 = faker.pystr()
+    existing_value1 = faker.pystr()
+    existing_var2 = faker.pystr()
+    existing_value2 = faker.pystr()
+
+    step = mocker.MagicMock(output_variables=[var1, var2, var3])
+
+    pipeline_variables = {
+        existing_var1: existing_value1,
+        existing_var2: existing_value2,
+    }
+    pipeline_ctx = mocker.MagicMock(
+        pipeline_variables=pipeline_variables,
+    )
+
+    vars_file = tmp_path / "vars.env"
+    vars_file.write_text(f"{var1}={value1}\n{var2}={value2}\n")
+
+    step_ctx = mocker.MagicMock(
+        step=step,
+        pipeline_ctx=pipeline_ctx,
+    )
+
+    runner = StepRunner(step_ctx)
+    runner._pipeline_variables_file = vars_file
+
+    runner._extract_output_variables()
+
+    expected_variables = {
+        existing_var1: existing_value1,
+        existing_var2: existing_value2,
+        var1: value1,
+        var2: value2,
+    }
+
+    assert pipeline_ctx.pipeline_variables == expected_variables
+
+
+def test_step_runner_extract_output_variables_overrides_existing_variables(
+    mocker: MockerFixture, faker: Faker, tmp_path: Path
+) -> None:
+    existing_var1 = faker.pystr()
+    existing_value1 = faker.pystr()
+    existing_var2 = faker.pystr()
+    existing_value2 = faker.pystr()
+
+    new_var1 = faker.pystr()
+    new_value1 = faker.pystr()
+    new_value2 = faker.pystr()
+
+    step = mocker.MagicMock(output_variables=[new_var1, existing_var2])
+
+    pipeline_variables = {
+        existing_var1: existing_value1,
+        existing_var2: existing_value2,
+    }
+    pipeline_ctx = mocker.MagicMock(
+        pipeline_variables=pipeline_variables,
+    )
+
+    vars_file = tmp_path / "vars.env"
+    vars_file.write_text(f"{new_var1}={new_value1}\n{existing_var2}={new_value2}\n")
+
+    step_ctx = mocker.MagicMock(
+        step=step,
+        pipeline_ctx=pipeline_ctx,
+    )
+
+    runner = StepRunner(step_ctx)
+    runner._pipeline_variables_file = vars_file
+
+    runner._extract_output_variables()
+
+    expected_variables = {
+        existing_var1: existing_value1,
+        existing_var2: new_value2,
+        new_var1: new_value1,
+    }
+
+    assert pipeline_ctx.pipeline_variables == expected_variables
+
+
+def test_step_runner_extract_output_variables_raises_an_error_on_unknown_variables(
+    mocker: MockerFixture, faker: Faker, tmp_path: Path
+) -> None:
+    var1 = faker.pystr()
+    value1 = faker.pystr()
+    var2 = faker.pystr()
+    value2 = faker.pystr()
+    var3 = faker.pystr()
+    value3 = faker.pystr()
+    var4 = faker.pystr()
+
+    step = mocker.MagicMock(output_variables=[var1, var4])
+
+    vars_file = tmp_path / "vars.env"
+    vars_file.write_text(f"{var1}={value1}\n{var2}={value2}\n{var3}={value3}\n")
+
+    step_ctx = mocker.MagicMock(step=step)
+
+    runner = StepRunner(step_ctx)
+    runner._pipeline_variables_file = vars_file
+
+    with pytest.raises(UsageError) as err_ctx:
+        runner._extract_output_variables()
+
+    assert var1 not in err_ctx.value.message
+    assert var2 in err_ctx.value.message
+    assert var3 in err_ctx.value.message
+
+
+def test_step_runner_extract_output_variables_raises_an_error_on_invalid_variables(
+    mocker: MockerFixture, faker: Faker, tmp_path: Path
+) -> None:
+    var = faker.pystr()
+    value = faker.pystr()
+
+    step = mocker.MagicMock(output_variables=[var])
+
+    vars_file = tmp_path / "vars.env"
+    vars_file.write_text(f"VALID_BUT_EMPTY=\nNOT_A_VALID_VAR\n{var}={value}\n")
+
+    step_ctx = mocker.MagicMock(step=step)
+
+    runner = StepRunner(step_ctx)
+    runner._pipeline_variables_file = vars_file
+
+    with pytest.raises(UsageError, match="Invalid variable format: NOT_A_VALID_VAR"):
+        runner._extract_output_variables()
+
+
+def test_step_runner_extract_output_variables_does_nothing_if_no_variables_set(mocker: MockerFixture) -> None:
+    step = mocker.MagicMock(output_variables=[])
+
+    pipeline_ctx = mocker.MagicMock()
+    pipeline_ctx.pipeline_variables.update.side_effect = Exception("Should not be called")
+
+    step_ctx = mocker.MagicMock(
+        step=step,
+        pipeline_ctx=pipeline_ctx,
+    )
+
+    runner = StepRunner(step_ctx)
+    runner._pipeline_variables_file = None
+
+    runner._extract_output_variables()


### PR DESCRIPTION
Add support for sharing variables between steps through the output variable mechanism. 
Reference: https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Shared-pipeline-variables

Fixes #65 