### PR TITLE
fix: Use `model_fields_set` to list available pipelines

### DIFF
--- a/pipeline_runner/models.py
+++ b/pipeline_runner/models.py
@@ -465,7 +465,7 @@ class Pipelines(BaseModel):
 
     def get_all(self) -> dict[str, Pipeline]:
         pipelines = {}
-        for attr in self.__annotations__:
+        for attr in self.model_fields_set:
             value = getattr(self, attr)
             if isinstance(value, Pipeline):
                 pipelines[attr] = value


### PR DESCRIPTION
Using `__annotations__` to list fields fields in `Pipelines` was probably a bad idea to begin with, but it worked, that is until python 3.14. The better solution is to use pydantic's `model_fields_set` which contains the names of the fields that were explicitly set. This fixes the listing of pipelines with python >= 3.14.

Fixes #75 