### PR TITLE
fix: Decode chunked execution log output incrementally to avoid UTF-8 errors

### DIFF
--- a/pipeline_runner/container.py
+++ b/pipeline_runner/container.py
@@ -1,4 +1,5 @@
 import base64
+import codecs
 import io
 import logging
 import os.path
@@ -362,11 +363,16 @@ class ContainerScriptRunner:
         self._print_execution_log(output_stream)
 
     def _print_execution_log(self, output_stream: Iterator[tuple[bytes, bytes]]) -> None:
+        # Use incremental decoders: the docker stream is chunked, so a multibyte
+        # UTF-8 character can be split across two chunks. Decoding each chunk
+        # independently would raise UnicodeDecodeError on the boundary.
+        stdout_decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        stderr_decoder = codecs.getincrementaldecoder("utf-8")("replace")
         for stdout, stderr in output_stream:
             if stdout:
-                self._stdout_print(stdout.decode().replace(GROUP_SEPARATOR, ""))
+                self._stdout_print(stdout_decoder.decode(stdout).replace(GROUP_SEPARATOR, ""))
             if stderr:
-                self._stderr_print(stderr.decode())
+                self._stderr_print(stderr_decoder.decode(stderr))
 
         self._stdout_print("\n")
 
@@ -398,9 +404,14 @@ class ContainerScriptRunnerWithExecTime(ContainerScriptRunner):
         self._timestamp: float | None = None
 
     def _print_execution_log(self, output_stream: Iterator[tuple[bytes, bytes]]) -> None:
+        # Use incremental decoders: the docker stream is chunked, so a multibyte
+        # UTF-8 character can be split across two chunks. Decoding each chunk
+        # independently would raise UnicodeDecodeError on the boundary.
+        stdout_decoder = codecs.getincrementaldecoder("utf-8")("replace")
+        stderr_decoder = codecs.getincrementaldecoder("utf-8")("replace")
         for stdout, stderr in output_stream:
             if stdout:
-                chunks = iter(stdout.decode().split(GROUP_SEPARATOR))
+                chunks = iter(stdout_decoder.decode(stdout).split(GROUP_SEPARATOR))
 
                 self._stdout_print(next(chunks))
 
@@ -408,7 +419,7 @@ class ContainerScriptRunnerWithExecTime(ContainerScriptRunner):
                     self._print_timing()
                     self._stdout_print(c)
             if stderr:
-                self._stderr_print(stderr.decode())
+                self._stderr_print(stderr_decoder.decode(stderr))
 
         self._print_timing()
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -358,7 +358,7 @@ def test_print_execution_log_decodes_utf8_char_split_across_chunks() -> None:
 
     # "café" is b"caf\xc3\xa9"; the multibyte "é" is split across two chunks, as
     # can happen with the chunked docker stream.
-    output_stream = iter([(b"caf\xc3", None), (b"\xa9", None)])
+    output_stream = iter([(b"caf\xc3", b""), (b"\xa9", b"")])
 
     runner._print_execution_log(output_stream)
 
@@ -372,7 +372,7 @@ def test_print_execution_log_with_exec_time_decodes_utf8_char_split_across_chunk
 
     # The multibyte "é" is split across two chunks, and a group separator must
     # still split the timing groups.
-    output_stream = iter([(b"caf\xc3", None), (b"\xa9" + GROUP_SEPARATOR.encode() + b"done", None)])
+    output_stream = iter([(b"caf\xc3", b""), (b"\xa9" + GROUP_SEPARATOR.encode() + b"done", b"")])
 
     runner._print_execution_log(output_stream)
 

--- a/tests/unit/test_container.py
+++ b/tests/unit/test_container.py
@@ -13,7 +13,10 @@ from pytest_mock import MockerFixture
 
 from pipeline_runner.config import Config
 from pipeline_runner.container import (
+    GROUP_SEPARATOR,
     ContainerRunner,
+    ContainerScriptRunner,
+    ContainerScriptRunnerWithExecTime,
     docker_is_docker_desktop,
     get_image_authentication,
     get_ssh_agent_socket_path,
@@ -347,3 +350,32 @@ def test_docker_is_docker_desktop(platform_name: str | None, expected: bool) -> 
         client.version.return_value = {"Platform": {}}
 
     assert docker_is_docker_desktop(client) == expected
+
+
+def test_print_execution_log_decodes_utf8_char_split_across_chunks() -> None:
+    logger = MagicMock()
+    runner = ContainerScriptRunner(MagicMock(), MagicMock(), output_logger=logger)
+
+    # "café" is b"caf\xc3\xa9"; the multibyte "é" is split across two chunks, as
+    # can happen with the chunked docker stream.
+    output_stream = iter([(b"caf\xc3", None), (b"\xa9", None)])
+
+    runner._print_execution_log(output_stream)
+
+    printed = "".join(c.args[0] for c in logger.info.call_args_list)
+    assert printed == "café\n"
+
+
+def test_print_execution_log_with_exec_time_decodes_utf8_char_split_across_chunks() -> None:
+    logger = MagicMock()
+    runner = ContainerScriptRunnerWithExecTime(MagicMock(), MagicMock(), output_logger=logger)
+
+    # The multibyte "é" is split across two chunks, and a group separator must
+    # still split the timing groups.
+    output_stream = iter([(b"caf\xc3", None), (b"\xa9" + GROUP_SEPARATOR.encode() + b"done", None)])
+
+    runner._print_execution_log(output_stream)
+
+    printed = "".join(c.args[0] for c in logger.info.call_args_list)
+    assert "café" in printed
+    assert "done" in printed


### PR DESCRIPTION
The Docker stream is read in chunks (stream=True, demux=True). _print_execution_log decoded each chunk in isolation, so a multibyte UTF-8 character split across a chunk boundary caused UnicodeDecodeError: unexpected end of data, aborting the pipeline.

This is easy to hit in practice with non-ASCII output: I'm Brazilian, and Portuguese routinely uses multibyte characters (é, ç, ã, etc.), so accented log output — plus emojis and box-drawing characters commonly printed by test runners — reliably triggers the crash whenever one lands on a 4096-byte chunk boundary.

Minimal reproduction (no Docker required — isolates the exact decode path):

```python
import codecs
# The Docker exec stream is delivered in chunks. "café" is b"caf\xc3\xa9";
# here the multibyte "é" (\xc3\xa9) is split across two chunks — exactly what
# happens when a multibyte character lands on a ~4096-byte chunk boundary.
chunks = [b"caf\xc3", b"\xa9"]

# Current behaviour: decoding each chunk on its own raises.
try:
    "".join(c.decode() for c in chunks)
except UnicodeDecodeError as e:
    print("before fix:", e)  # 'utf-8' codec can't decode byte 0xc3 ... unexpected end of data
    
# On pipeline runner, the error shows up as:
# site-packages\pipeline_runner\container.py", line 403, in _print_execution_log
#     chunks = iter(stdout.decode().split(GROUP_SEPARATOR))
#                   ^^^^^^^^^^^^^^^
# UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 4094-4095: unexpected end of data

# Fix: an incremental decoder buffers the partial sequence across chunks.
dec = codecs.getincrementaldecoder("utf-8")("replace")
decoded = "".join(dec.decode(c) for c in chunks)
assert decoded == "café"
print("after fix:", decoded)
```

Fix: replace the per-chunk decode with codecs.getincrementaldecoder("utf-8")("replace"), which buffers partial bytes across chunks. Includes tests for both _print_execution_log variants.